### PR TITLE
1.1.4

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -28,6 +28,8 @@ jobs:
           cache: gradle
       - name: 'Building App JARs'
         run: make build-app
+      - name: 'Validating App Properties Config'
+        run: make validate-app-properties
       - name: 'Building App Properties Config'
         run: make build-app-properties
       - name: 'Uploading generated properties file'

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ build-app:
 	@echo "## Building the application ..."
 	$(call toolchain_runner, ./gradlew build -x test --info)
 
+validate-app-properties:
+	@echo "## Validating the application properties for \"$(ENVIRONMENT)\" ..."
+	$(call toolchain_runner, ./gradlew validateApplicationProperties --info \
+		-Penvironments=$(PROPACTIVE_PROPERTIES_ENV_TO_GENERATE))
+
 build-app-properties:
 	@echo "## Building the application properties for \"$(ENVIRONMENT)\" ..."
 	$(call toolchain_runner, ./gradlew generateApplicationProperties --info \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ import org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "1.6.20"
-    val propactiveVersion = "1.1.0"
+    val kotlinVersion = "1.8.0"
+    val propactiveVersion = "1.1.4"
 
     application
 
@@ -18,6 +18,7 @@ version = System.getenv("VERSION") ?: "DEV-SNAPSHOT"
 
 propactive {
     implementationClass = "io.github.propactive.demo.Properties"
+    destination = layout.buildDirectory.dir("properties").get().asFile.absolutePath
 }
 
 application {
@@ -37,6 +38,7 @@ application {
 }
 
 repositories {
+    mavenLocal() // This is needed for (SNAPSHOT TESTING)
     mavenCentral()
 }
 
@@ -46,6 +48,7 @@ dependencies {
     val propactiveVersion: String by project
 
     implementation("io.github.propactive:propactive-jvm:$propactiveVersion")
+
     testImplementation("org.junit.jupiter:junit-jupiter:$jupiterVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ mainClassReference=io.github.propactive.Launcher
 
 kotlin.code.style=official
 
-kotlinVersion=1.6.20
+kotlinVersion=1.8.0
 jupiterVersion=5.9.0
 kotestVersion=5.4.2
-propactiveVersion=1.1.0
+propactiveVersion=1.1.4

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,9 @@
 rootProject.name = "propactive-demo"
+
+pluginManagement {
+    repositories {
+        mavenLocal() // This is needed for (SNAPSHOT TESTING)
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
- Upgrade to Propactive 1.1.4 
- Configure the plugin to generate the files in the build directory as it's no longer the default. (see: https://github.com/propactive/propactive/releases/tag/1.1.3)
- Create validation recipe (validate-app-properties) and add it as a step in CD workflow.